### PR TITLE
[2.x] - Change how Comment model relationships and tables work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Upgrade Guide from 1.0 to 2.0
 - Namespace for `SethSharp\BlogCrud\Models\File` has changed to `SethSharp\BlogCrud\Models\Blog`
-- With the changes from [PR#5](), I suggest writing a command going through all blog comments then update the comment relationship column `blog_id` to the current blog... then drop `blog_comments`
+- With the changes from [PR#5](https://github.com/SethSharp/BlogCrud/pull/5), I suggest writing a command going through all blog comments then update the comment relationship column `blog_id` to the current blog... then drop `blog_comments`
 
 ## V2.0
 - Moves File to proper location under `Models/Blog/` [Pull Request #3](https://github.com/SethSharp/BlogCrud/pull/3)
 - Add missing size rules in requests [Pull Request #4](https://github.com/SethSharp/BlogCrud/pull/4)
-- Changes how the relationship & tables work with Comments [Pull Request #5]()
+- Changes how the relationship & tables work with Comments [Pull Request #5](https://github.com/SethSharp/BlogCrud/pull/5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 ## V2.0
 - Moves File to proper location under `Models/Blog/` [Pull Request #3](https://github.com/SethSharp/BlogCrud/pull/3)
 - Add missing size rules in requests [Pull Request #4](https://github.com/SethSharp/BlogCrud/pull/4)
+- Changes how the relationship & tables work with Comments [Pull Request #5]()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upgrade Guide from 1.0 to 2.0
 - Namespace for `SethSharp\BlogCrud\Models\File` has changed to `SethSharp\BlogCrud\Models\Blog`
+- With the changes from [PR#5](), I suggest writing a command going through all blog comments then update the comment relationship column `blog_id` to the current blog... then drop `blog_comments`
 
 ## V2.0
 - Moves File to proper location under `Models/Blog/` [Pull Request #3](https://github.com/SethSharp/BlogCrud/pull/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@
 ## V2.0
 - Moves File to proper location under `Models/Blog/` [Pull Request #3](https://github.com/SethSharp/BlogCrud/pull/3)
 - Add missing size rules in requests [Pull Request #4](https://github.com/SethSharp/BlogCrud/pull/4)
-- Changes how the relationship & tables work with Comments [Pull Request #5](https://github.com/SethSharp/BlogCrud/pull/5)
+- Change how Comment model relationships and tables work [Pull Request #5](https://github.com/SethSharp/BlogCrud/pull/5)

--- a/database/migrations/2024_06_14_012817_drop_blog_comment_table.php
+++ b/database/migrations/2024_06_14_012817_drop_blog_comment_table.php
@@ -10,6 +10,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::drop('blogs_comment');
+        Schema::drop('blog_comment');
     }
 };

--- a/database/migrations/2024_06_14_012817_drop_blog_comment_table.php
+++ b/database/migrations/2024_06_14_012817_drop_blog_comment_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::drop('blogs_comment');
+    }
+};

--- a/database/migrations/2024_06_14_012828_add_blog_id_to_comments_table.php
+++ b/database/migrations/2024_06_14_012828_add_blog_id_to_comments_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('comments', function (Blueprint $table) {
+            $table->foreignId('blog_id')->after('user_id');
+        });
+    }
+};

--- a/src/Database/Factories/Domain/Blog/Models/BlogFactory.php
+++ b/src/Database/Factories/Domain/Blog/Models/BlogFactory.php
@@ -30,12 +30,12 @@ class BlogFactory extends Factory
         ];
     }
 
-    public function configure(): self
+    public function withComments(int $count = 3): self
     {
-        return $this->afterCreating(function ($blog) {
-            $comments = Comment::factory()->count(3)->create()->pluck('id');
-
-            $blog->comments()->attach($comments);
+        return $this->afterCreating(function (Blog $blog) use ($count) {
+            Comment::factory()->count($count)->create([
+                'blog_id' => $blog->id
+            ]);
         });
     }
 

--- a/src/Database/Factories/Domain/Blog/Models/CommentFactory.php
+++ b/src/Database/Factories/Domain/Blog/Models/CommentFactory.php
@@ -3,6 +3,7 @@
 namespace SethSharp\BlogCrud\Database\Factories\Domain\Blog\Models;
 
 use SethSharp\BlogCrud\Models\Iam\User;
+use SethSharp\BlogCrud\Models\Blog\Blog;
 use SethSharp\BlogCrud\Models\Blog\Comment;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -14,6 +15,7 @@ class CommentFactory extends Factory
     {
         return [
             'user_id' => User::factory(),
+            'blog_id' => Blog::factory(),
             'comment' => $this->faker->text(100),
         ];
     }

--- a/src/Models/Blog/Blog.php
+++ b/src/Models/Blog/Blog.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use SethSharp\BlogCrud\Support\Cache\CacheKeys;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use SethSharp\BlogCrud\Support\Editor\Nodes\EditorNodes;
@@ -42,10 +43,9 @@ class Blog extends Model
         return $this->belongsTo(config('blog-crud.models.iam.user'), 'author_id');
     }
 
-    public function comments(): BelongsToMany
+    public function comments(): HasMany
     {
-        return $this->belongsToMany(config('blog-crud.models.blog.comment'), 'blog_comment', 'blog_id', 'comment_id')
-            ->withTimestamps();
+        return $this->hasMany(config('blog-crud.models.blog.comment'));
     }
 
     public function likes(): BelongsToMany

--- a/src/Models/Blog/Comment.php
+++ b/src/Models/Blog/Comment.php
@@ -3,10 +3,9 @@
 namespace SethSharp\BlogCrud\Models\Blog;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use SethSharp\BlogCrud\Models\Events\CommentCreatedEvent;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use SethSharp\BlogCrud\Database\Factories\Domain\Blog\Models\CommentFactory;
 
 class Comment extends Model
@@ -24,13 +23,13 @@ class Comment extends Model
         return new CommentFactory();
     }
 
-    public function blogs(): BelongsToMany
+    public function blog(): BelongsTo
     {
-        return $this->belongsToMany(config('blog-crud.models.blog.blog'), 'blog_comment', 'comment_id', 'blog_id');
+        return $this->belongsTo(config('blog-crud.models.blog.blog'));
     }
 
-    public function user(): HasOne
+    public function user(): BelongsTo
     {
-        return $this->hasOne(config('blog-crud.models.iam.user'), 'id', 'user_id');
+        return $this->belongsTo(config('blog-crud.models.iam.user'));
     }
 }

--- a/src/Models/Blog/Comment.php
+++ b/src/Models/Blog/Comment.php
@@ -3,6 +3,7 @@
 namespace SethSharp\BlogCrud\Models\Blog;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use SethSharp\BlogCrud\Models\Events\CommentCreatedEvent;
@@ -13,6 +14,8 @@ class Comment extends Model
     use HasFactory;
 
     protected $guarded = [];
+
+    protected $appends = ['posted'];
 
     protected $dispatchesEvents = [
         'created' => CommentCreatedEvent::class
@@ -31,5 +34,12 @@ class Comment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(config('blog-crud.models.iam.user'));
+    }
+
+    public function posted(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->created_at->diffForHumans()
+        );
     }
 }

--- a/src/Models/Iam/User.php
+++ b/src/Models/Iam/User.php
@@ -35,9 +35,9 @@ class User extends Authenticatable
         return $this->hasMany(config('blog-crud.models.blog.blog'));
     }
 
-    public function comments(): BelongsToMany
+    public function comments(): HasMany
     {
-        return $this->belongsToMany(config('blog-crud.models.blog.comment'), 'comments')
+        return $this->hasMany(config('blog-crud.models.blog.comment'))
             ->withTimestamps();
     }
 


### PR DESCRIPTION

Things that have changed:
- Drops `blog_comment` table as this is now redundant
- Add foreignId to comments table, `blog_id`
- Blog relationship has been change to a `HasMany` relationship
- Comment has relationships
   - User `BelongsToOne` and
   - Blog `BelongsToOne`
- Users relationship has been changed to a `HasMany` relationship
- posted attribute is now appended to Comment model
- Comments are no longer created automatically, must define the `withComments` factory state. Which accepts a comment count value (defaults to 3)